### PR TITLE
fix: block scheduling in the past

### DIFF
--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -38,6 +38,10 @@ class ScheduledNotification
         Notification $notification,
         DateTimeInterface $sendAt
     ): self {
+        if ($sendAt <= Carbon::now()->subMinute()) {
+            throw new SchedulingFailedException(sprintf('`send_at` must not be in the past: %s', $sendAt->format(DATE_ISO8601)));
+        }
+
         if (! method_exists($notifiable, 'notify')) {
             throw new SchedulingFailedException(sprintf('%s is not notifiable', get_class($notifiable)));
         }

--- a/tests/ScheduledNotificationTest.php
+++ b/tests/ScheduledNotificationTest.php
@@ -179,6 +179,18 @@ class ScheduledNotificationTest extends TestCase
         );
     }
 
+    public function testCannotCreateNotificationWithPastSentAt()
+    {
+        $this->expectException(SchedulingFailedException::class);
+        $target = User::find(1);
+
+        ScheduledNotification::create(
+            $target,
+            new TestNotification(User::find(2)),
+            Carbon::now()->subHour()
+        );
+    }
+
     public function testNotificationsCanBeQueried()
     {
         Notification::fake();


### PR DESCRIPTION
You shouldn't be able to schedule notifications in the past. This adds an exception if you try.