### PR TITLE
fix: cancel interrupted notifications

### DIFF
--- a/src/Models/ScheduledNotification.php
+++ b/src/Models/ScheduledNotification.php
@@ -66,6 +66,7 @@ class ScheduledNotification extends Model
         $notification = $this->serializer->unserializeNotification($this->notification);
 
         if ($this->shouldInterrupt($notification)) {
+            $this->cancel();
             event(new NotificationInterrupted($this));
 
             return;

--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -186,6 +186,11 @@ class ScheduledNotification
         $this->scheduleNotificationModel->send();
     }
 
+    public function refresh(): void
+    {
+        $this->scheduleNotificationModel->refresh();
+    }
+
     public function isSent(): bool
     {
         return $this->scheduleNotificationModel->sent_at !== null;

--- a/tests/CanInterruptNotificationTest.php
+++ b/tests/CanInterruptNotificationTest.php
@@ -29,7 +29,9 @@ class CanInterruptNotificationTest extends TestCase
 
         // Assert
         // Check wasn't sent (exception?)
+        $notification->refresh();
         $this->assertFalse($notification->isSent());
+        $this->assertTrue($notification->isCancelled());
         $this->assertTrue($notification->getShouldInterrupt());
 
         Notification::assertNothingSent();


### PR DESCRIPTION
I realised when we interrupt a notification we aren't actually cancelling it.

This means that Snooze will try and sent it every minute until it falls out the tolerance.

This PR fixes that by cancelling it (and thus snooze no longer tries to send it).
