### PR TITLE
feat: report exceptions when sending

### DIFF
--- a/src/Console/Commands/SendScheduledNotifications.php
+++ b/src/Console/Commands/SendScheduledNotifications.php
@@ -4,7 +4,6 @@ namespace Thomasjohnkane\Snooze\Console\Commands;
 
 use Carbon\Carbon;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Log;
 use Thomasjohnkane\Snooze\Models\ScheduledNotification;
 
 class SendScheduledNotifications extends Command
@@ -58,8 +57,8 @@ class SendScheduledNotifications extends Command
             try {
                 $notification->send();
             } catch (\Exception $e) {
+                report($e);
                 $this->error($e->getMessage());
-                Log::error(sprintf('Failed to send notification: %s', $e->getMessage()));
             }
         });
 

--- a/tests/SendCommandTest.php
+++ b/tests/SendCommandTest.php
@@ -67,7 +67,7 @@ class SendCommandTest extends TestCase
         $model->save();
 
         Log::shouldReceive('error')
-            ->with('Failed to send notification: unserialize(): Error at offset 0 of 10 bytes');
+            ->withSomeOfArgs('unserialize(): Error at offset 0 of 10 bytes');
 
         $this->artisan('snooze:send')
             ->expectsOutput('Starting Sending Scheduled Notifications')


### PR DESCRIPTION
- report exceptions to laravel's exception handler instead of logging
- update test to confirm that exceptions are still logged

Closes #32 