### PR TITLE
Added missing closing parenthesis to the docs examples

### DIFF
--- a/docs/examples/on-boarding-email-drip.md
+++ b/docs/examples/on-boarding-email-drip.md
@@ -49,9 +49,9 @@ class User {
     {
         $now = Carbon::now();
    
-        $user->notifyAt(new SignUpConfirmation($user), Carbon::now()->addHour();
-        $user->notifyAt(new WelcomeToCommunity($user), Carbon::now()->addDays(3);
-        $user->notifyAt(new UpsellSubscription($user), Carbon::now()->addWeek();
+        $user->notifyAt(new SignUpConfirmation($user), Carbon::now()->addHour());
+        $user->notifyAt(new WelcomeToCommunity($user), Carbon::now()->addDays(3));
+        $user->notifyAt(new UpsellSubscription($user), Carbon::now()->addWeek());
     }
     ```
 


### PR DESCRIPTION
**What does this PR do?**
Added missing closing parenthesis to the docs examples in simple on-boarding email drip