### PR TITLE
fix table name reference in ScheduledNotification model

### DIFF
--- a/src/Models/ScheduledNotification.php
+++ b/src/Models/ScheduledNotification.php
@@ -48,7 +48,7 @@ class ScheduledNotification extends Model
     {
         parent::__construct($attributes);
 
-        $this->table = config('snooze.snooze_table');
+        $this->table = config('snooze.table');
         $this->serializer = app(Serializer::class);
     }
 


### PR DESCRIPTION
When customizing the table name, the config entry shall be retrievied from `config('snooze.table')` and not `config('snooze.snooze_table')`