### PR TITLE
Feature/disable scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,9 @@ If this method is not present on your notification, the notification will *not* 
 
 **Conditionally turn off scheduler**
 
-If you would like to turn off all notifications for your app, set an env variable of `SCHEDULED_NOTIFICATIONS_DISABLED` to `true` and it will turn off the auto scheduler. 
+If you would like to disable sending of scheduled notifications, set an env variable of `SCHEDULED_NOTIFICATIONS_DISABLED` to `true`. You will still be able to schedule notifications, and they will be sent once the scheduler is enabled.
+
+This could be useful for ensuring that scheduled notifications are only sent by a specific server, for example.
 
 ## Running the Tests
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ public function shouldInterrupt($notifiable) {
 
 If this method is not present on your notification, the notification will *not* be interrupted. Consider creating a shouldInterupt trait if you'd like to repeat conditional logic on groups of notifications.
 
+**Conditionally turn off scheduler**
+
+If you would like to turn off all notifications for your app, set an env variable of `SNOOZE_CANCEL_SCHEDULE` to `true` and it will turn off the scheduler
+
 ## Running the Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ If this method is not present on your notification, the notification will *not* 
 
 **Conditionally turn off scheduler**
 
-If you would like to turn off all notifications for your app, set an env variable of `SNOOZE_CANCEL_SCHEDULE` to `true` and it will turn off the scheduler
+If you would like to turn off all notifications for your app, set an env variable of `SCHEDULED_NOTIFICATIONS_DISABLED` to `true` and it will turn off the auto scheduler. 
 
 ## Running the Tests
 

--- a/config/snooze.php
+++ b/config/snooze.php
@@ -35,10 +35,9 @@ return [
      */
     'pruneAge' => env('SCHEDULED_NOTIFICATION_PRUNE_AGE', null),
 
-
     /*
      * Use this to disable the auto scheduling of the notifications
      */
 
-    'disabled' => env('SCHEDULED_NOTIFICATIONS_DISABLED', false)
+    'disabled' => env('SCHEDULED_NOTIFICATIONS_DISABLED', false),
 ];

--- a/config/snooze.php
+++ b/config/snooze.php
@@ -34,4 +34,11 @@ return [
      * If set to null, pruning will be turned off. By default it's turned off
      */
     'pruneAge' => env('SCHEDULED_NOTIFICATION_PRUNE_AGE', null),
+
+
+    /*
+     * Use this to disable the auto scheduling of the notifications
+     */
+
+    'disabled' => env('SCHEDULED_NOTIFICATIONS_DISABLED', false)
 ];

--- a/config/snooze.php
+++ b/config/snooze.php
@@ -36,7 +36,9 @@ return [
     'pruneAge' => env('SCHEDULED_NOTIFICATION_PRUNE_AGE', null),
 
     /*
-     * Use this to disable the auto scheduling of the notifications
+     * Disable sending of scheduled notifications
+     * You will still be able to schedule notifications,
+     * and they will be sent once the scheduler is enabled.
      */
 
     'disabled' => env('SCHEDULED_NOTIFICATIONS_DISABLED', false),

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,7 +17,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         // Schedule base command to run every minute
         $this->app->booted(function () {
-            if (! env('SNOOZE_CANCEL_SCHEDULE', false)) {
+            if (! config('snooze.disabled')) {
                 $frequency = config('snooze.sendFrequency', 'everyMinute');
                 $schedule = $this->app->make(Schedule::class);
                 $schedule->command('snooze:send')->{$frequency}();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,11 +17,12 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         // Schedule base command to run every minute
         $this->app->booted(function () {
-            $shouldCancelSchedule = env('SNOOZE_CANCEL_SCHEDULE', false);
-            if($shouldCancelSchedule) return;
-            $frequency = config('snooze.sendFrequency', 'everyMinute');
-            $schedule = $this->app->make(Schedule::class);
-            $schedule->command('snooze:send')->{$frequency}();
+            if(!env('SNOOZE_CANCEL_SCHEDULE', false)) {
+                $frequency = config('snooze.sendFrequency', 'everyMinute');
+                $schedule = $this->app->make(Schedule::class);
+                $schedule->command('snooze:send')->{$frequency}();
+            }
+
 
             if (config('snooze.pruneAge') !== null) {
                 $schedule->command('snooze:prune')->daily();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,6 +17,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         // Schedule base command to run every minute
         $this->app->booted(function () {
+            $shouldCancelSchedule = env('SNOOZE_CANCEL_SCHEDULE', false);
+            if($shouldCancelSchedule) return;
             $frequency = config('snooze.sendFrequency', 'everyMinute');
             $schedule = $this->app->make(Schedule::class);
             $schedule->command('snooze:send')->{$frequency}();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,7 +17,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         // Schedule base command to run every minute
         $this->app->booted(function () {
-            if(!env('SNOOZE_CANCEL_SCHEDULE', false)) {
+            if(! env('SNOOZE_CANCEL_SCHEDULE', false)) {
                 $frequency = config('snooze.sendFrequency', 'everyMinute');
                 $schedule = $this->app->make(Schedule::class);
                 $schedule->command('snooze:send')->{$frequency}();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,7 +17,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         // Schedule base command to run every minute
         $this->app->booted(function () {
-            if(! env('SNOOZE_CANCEL_SCHEDULE', false)) {
+            if (! env('SNOOZE_CANCEL_SCHEDULE', false)) {
                 $frequency = config('snooze.sendFrequency', 'everyMinute');
                 $schedule = $this->app->make(Schedule::class);
                 $schedule->command('snooze:send')->{$frequency}();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -23,7 +23,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 $schedule->command('snooze:send')->{$frequency}();
             }
 
-
             if (config('snooze.pruneAge') !== null) {
                 $schedule->command('snooze:prune')->daily();
             }


### PR DESCRIPTION
Feel free to not accept this, but I have need of being able to turn off the automatic scheduling. I have shared models across multiple repos and I only need the scheduling to run in one repo. 