### PR TITLE
Fix using a custom model

### DIFF
--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -21,9 +21,10 @@ class ScheduledNotification
     /** @var ScheduledNotificationModel */
     private $scheduleNotificationModel;
 
-    public function __construct(ScheduledNotificationModel $scheduleNotificationModel)
+    public function __construct()
     {
-        $this->scheduleNotificationModel = $scheduleNotificationModel;
+        $modelName = self::getScheduledNotificationModelClass();
+        $this->scheduleNotificationModel = new $modelName;
     }
 
     /**


### PR DESCRIPTION
If use a custom model, the new model would not be injected into Scheduled Notification class, 
so in order to inject new custom model, should get scheduled notification model name from config file and instantiate it.