### PR TITLE
Fix for breakage if snooze disabled but pruneAge set

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Laravel Snooze
 
 ### Why the fork?
 We required some additional functionalities to this package, but it didn't look like new PR's were getting accepted.
-Therefore we decided to use a forked version of the package and add our changes
+
+The decision was made to fork the package and continue to add our requirements.
+
+Please note that the changes made is purely for our own needs, all props still go to original developer of this package.
+Thanks for all the hard work on this!
 
 ### Why use this package?
 - Ever wanted to schedule a <b>future</b> notification to go out at a specific time? (was the delayed queue option not enough?)

--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ Laravel Snooze
 [![Total Downloads](https://poser.pugx.org/thomasjohnkane/snooze/downloads)](https://packagist.org/packages/thomasjohnkane/snooze)
 [![License](https://poser.pugx.org/thomasjohnkane/snooze/license)](https://packagist.org/packages/thomasjohnkane/snooze)
 
+### Why the fork?
+We required some additional functionalities to this package, but it didn't look like new PR's were getting accepted.
+Therefore we decided to use a forked version of the package and add our changes
+
 ### Why use this package?
-- Ever wanted to schedule a <b>future</b> notification to go out at a specific time? (was the delayed queue option not enough?) 
+- Ever wanted to schedule a <b>future</b> notification to go out at a specific time? (was the delayed queue option not enough?)
 - Want a simple on-boarding email drip?
 - How about happy birthday emails?
 
@@ -44,7 +48,7 @@ php artisan vendor:publish --provider="Thomasjohnkane\Snooze\ServiceProvider" --
 ## Usage
 
 #### Using the model trait
-Snooze provides a trait for your model, similar to the standard `Notifiable` trait. 
+Snooze provides a trait for your model, similar to the standard `Notifiable` trait.
 It adds a `notifyAt()` method to your model to schedule notifications.
 
 ```php
@@ -67,7 +71,7 @@ $user->notifyAt(new NewYearNotification, Carbon::parse('last day of this year'))
 ```
 
 #### Using the ScheduledNotification::create helper
-You can also use the `create` method on the `ScheduledNotification`. 
+You can also use the `create` method on the `ScheduledNotification`.
 ```php
 ScheduledNotification::create(
      Auth::user(), // Target
@@ -91,7 +95,7 @@ ScheduledNotification::create(
 
 #### An important note about scheduling the `snooze:send` command
 
-Creating a scheduled notification will add the notification to the database. It will be sent by running `snooze:send` command at (or after) the stored `sendAt` time. 
+Creating a scheduled notification will add the notification to the database. It will be sent by running `snooze:send` command at (or after) the stored `sendAt` time.
 
 The `snooze:send` command is scheduled to run every minute by default. You can change this value (`sendFrequency`) in the published config file. Available options are `everyMinute`, `everyFiveMinutes`, `everyTenMinutes`, `everyFifteenMinutes`, `everyThirtyMinutes`, `hourly`, and `daily`.
 
@@ -99,15 +103,15 @@ The only thing you need to do is make sure `schedule:run` is also running. You c
 
 ### Setting the send tolerance
 
-If your scheduler stops working, a backlog of scheduled notifications will build up. To prevent users receiving all of 
-the old scheduled notifications at once, the command will only send mail within the configured tolerance. 
+If your scheduler stops working, a backlog of scheduled notifications will build up. To prevent users receiving all of
+the old scheduled notifications at once, the command will only send mail within the configured tolerance.
 By default this is set to 24 hours, so only mail scheduled to be sent within that window will be sent. This can be
-configured (in seconds) using the `SCHEDULED_NOTIFICATION_SEND_TOLERANCE` environment variable or in the `snooze.php` config file. 
+configured (in seconds) using the `SCHEDULED_NOTIFICATION_SEND_TOLERANCE` environment variable or in the `snooze.php` config file.
 
 ### Setting the prune age
 
 The package can prune sent and cancelled messages that were sent/cancelled more than x days ago. You can
-configure this using the `SCHEDULED_NOTIFICATION_PRUNE_AGE` environment variable or in the `snooze.php` config file 
+configure this using the `SCHEDULED_NOTIFICATION_PRUNE_AGE` environment variable or in the `snooze.php` config file
 (unit is days). This feature is turned off by default.
 
 #### Detailed Examples

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "thomasjohnkane/snooze",
+  "name": "zero2one/snooze",
   "description": "Schedule future notifications and reminders in Laravel",
   "license": "MIT",
   "keywords": [
@@ -13,10 +13,14 @@
     {
       "name": "Thomas Kane",
       "email": "thomasjohnkane@gmail.com"
+    },
+    {
+      "name": "Ricus Swanepoel",
+      "email": "ricus@zero2one.co.za"
     }
   ],
   "require": {
-    "php": ">=7.2.5",
+    "php": ">=8.0",
     "illuminate/support": "~6.0 || ~7.0 || ~8.0"
   },
   "require-dev": {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,9 +17,11 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         // Schedule base command to run every minute
         $this->app->booted(function () {
+            //Ensure the schedule is available if snooze is disabled but a prune age is set
+            $schedule = $this->app->make(Schedule::class);
+
             if (! config('snooze.disabled')) {
                 $frequency = config('snooze.sendFrequency', 'everyMinute');
-                $schedule = $this->app->make(Schedule::class);
                 $schedule->command('snooze:send')->{$frequency}();
             }
 


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/thomasjohnkane/snooze/pull/73

The referenced PR added the ability to disable snoozing, however the package could be left in an error state if snooze is disabled, but there is a pruneAge config value this.

This is because the instance of the scheduler is only created if snooze is enabled, however the instance is required when `snooze.pruneAge` has a non-null value.

The fix in this pr just moves the   `$schedule = $this->app->make(Schedule::class);` line to above the check for snooze enabled, so that the instance is accessible for the prune command.