### PR TITLE
Allow onOneServer via env/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,6 @@ SCHEDULED_NOTIFICATIONS_ONE_SERVER = true
 
 ```
 
-
-
 ## Running the Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ If you would like to disable sending of scheduled notifications, set an env vari
 
 This could be useful for ensuring that scheduled notifications are only sent by a specific server, for example.
 
+**Enable onOneServer**
+
+If you would like the `snooze` commands to utilise the Laravel Scheduler's `onOneServer` functionality, you can use the following environment variable:
+
+```bash
+
+SCHEDULED_NOTIFICATIONS_ONE_SERVER = true
+
+```
+
+
+
 ## Running the Tests
 
 ```bash

--- a/config/snooze.php
+++ b/config/snooze.php
@@ -40,6 +40,10 @@ return [
      * You will still be able to schedule notifications,
      * and they will be sent once the scheduler is enabled.
      */
-
     'disabled' => env('SCHEDULED_NOTIFICATIONS_DISABLED', false),
+
+    /*
+     * Should the snooze commands utilise the Laravel onOneServer functionality
+     */
+    'onOneServer' => env('SCHEDULED_NOTIFICATIONS_ONE_SERVER', false),
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -20,11 +20,22 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             if (! config('snooze.disabled')) {
                 $frequency = config('snooze.sendFrequency', 'everyMinute');
                 $schedule = $this->app->make(Schedule::class);
-                $schedule->command('snooze:send')->{$frequency}();
+
+                if (config('snooze.onOneServer', false)) {
+                    $schedule->command('snooze:send')->{$frequency}()->onOneServer();
+                } else {
+                    $schedule->command('snooze:send')->{$frequency}();
+                }
+
             }
 
             if (config('snooze.pruneAge') !== null) {
-                $schedule->command('snooze:prune')->daily();
+                if (config('snooze.onOneServer', false)) {
+                    $schedule->command('snooze:prune')->daily()->onOneServer();
+                } else {
+                    $schedule->command('snooze:prune')->daily();
+                }
+
             }
         });
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,7 +26,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 } else {
                     $schedule->command('snooze:send')->{$frequency}();
                 }
-
             }
 
             if (config('snooze.pruneAge') !== null) {
@@ -35,7 +34,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 } else {
                     $schedule->command('snooze:prune')->daily();
                 }
-
             }
         });
 


### PR DESCRIPTION
Hello,

This PR adds the ability to run the snooze commands through the `onOneServer` functionality provided by the Laravel Schedule.

I had the same issue as https://github.com/thomasjohnkane/snooze/issues/78 but didn't look like a PR had been made.

## Changes
New Environment variable: `SCHEDULED_NOTIFICATIONS_ONE_SERVER`
and Config variable: `snooze.onOneServer`


## Notes
* I didn't know if prune should also be included, but i think it makes sense.
* I felt like the disable statement above should also have wrapped around prune also, but didn't want to combine that in this PR
* I attempted to write a test but struggled due to the Scheduler code not existing in the repo which made it hard to write a Mock for it
