### PR TITLE
Fix for breakage if snooze disabled but pruneAge set 

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,10 +17,12 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         // Schedule base command to run every minute
         $this->app->booted(function () {
+
+            //Ensure the schedule is available if snooze is disabled but a prune age is set
+            $schedule = $this->app->make(Schedule::class);
+
             if (! config('snooze.disabled')) {
                 $frequency = config('snooze.sendFrequency', 'everyMinute');
-                $schedule = $this->app->make(Schedule::class);
-
                 if (config('snooze.onOneServer', false)) {
                     $schedule->command('snooze:send')->{$frequency}()->onOneServer();
                 } else {


### PR DESCRIPTION
@atymic here is the first pr again, still working on the meta column one

This PR fixes an issue introduced in #73

The referenced PR added the ability to disable snoozing, however the package could be left in an error state if snooze is disabled, but there is a pruneAge config value this.

This is because the instance of the scheduler is only created if snooze is enabled, however the instance is required when snooze.pruneAge has a non-null value.

The fix in this pr just moves the $schedule = $this->app->make(Schedule::class); line to above the check for snooze enabled, so that the instance is accessible for the prune command.