### PR TITLE
Feature: Meta JSON column for scheduled notifications (Easier Querying)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Laravel Snooze
 [![License](https://poser.pugx.org/thomasjohnkane/snooze/license)](https://packagist.org/packages/thomasjohnkane/snooze)
 
 ### Why use this package?
-- Ever wanted to schedule a <b>future</b> notification to go out at a specific time? (was the delayed queue option not enough?) 
+- Ever wanted to schedule a <b>future</b> notification to go out at a specific time? (was the delayed queue option not enough?)
 - Want a simple on-boarding email drip?
 - How about happy birthday emails?
 
@@ -44,7 +44,7 @@ php artisan vendor:publish --provider="Thomasjohnkane\Snooze\ServiceProvider" --
 ## Usage
 
 #### Using the model trait
-Snooze provides a trait for your model, similar to the standard `Notifiable` trait. 
+Snooze provides a trait for your model, similar to the standard `Notifiable` trait.
 It adds a `notifyAt()` method to your model to schedule notifications.
 
 ```php
@@ -68,7 +68,7 @@ $user->notifyAt(new NewYearNotification, Carbon::parse('last day of this year'))
 ```
 
 #### Using the ScheduledNotification::create helper
-You can also use the `create` method on the `ScheduledNotification`. 
+You can also use the `create` method on the `ScheduledNotification`.
 ```php
 ScheduledNotification::create(
      Auth::user(), // Target
@@ -92,7 +92,7 @@ ScheduledNotification::create(
 
 #### An important note about scheduling the `snooze:send` command
 
-Creating a scheduled notification will add the notification to the database. It will be sent by running `snooze:send` command at (or after) the stored `sendAt` time. 
+Creating a scheduled notification will add the notification to the database. It will be sent by running `snooze:send` command at (or after) the stored `sendAt` time.
 
 The `snooze:send` command is scheduled to run every minute by default. You can change this value (`sendFrequency`) in the published config file. Available options are `everyMinute`, `everyFiveMinutes`, `everyTenMinutes`, `everyFifteenMinutes`, `everyThirtyMinutes`, `hourly`, and `daily`.
 
@@ -100,15 +100,15 @@ The only thing you need to do is make sure `schedule:run` is also running. You c
 
 ### Setting the send tolerance
 
-If your scheduler stops working, a backlog of scheduled notifications will build up. To prevent users receiving all of 
-the old scheduled notifications at once, the command will only send mail within the configured tolerance. 
+If your scheduler stops working, a backlog of scheduled notifications will build up. To prevent users receiving all of
+the old scheduled notifications at once, the command will only send mail within the configured tolerance.
 By default this is set to 24 hours, so only mail scheduled to be sent within that window will be sent. This can be
-configured (in seconds) using the `SCHEDULED_NOTIFICATION_SEND_TOLERANCE` environment variable or in the `snooze.php` config file. 
+configured (in seconds) using the `SCHEDULED_NOTIFICATION_SEND_TOLERANCE` environment variable or in the `snooze.php` config file.
 
 ### Setting the prune age
 
 The package can prune sent and cancelled messages that were sent/cancelled more than x days ago. You can
-configure this using the `SCHEDULED_NOTIFICATION_PRUNE_AGE` environment variable or in the `snooze.php` config file 
+configure this using the `SCHEDULED_NOTIFICATION_PRUNE_AGE` environment variable or in the `snooze.php` config file
 (unit is days). This feature is turned off by default.
 
 #### Detailed Examples
@@ -164,6 +164,53 @@ public function shouldInterrupt($notifiable) {
 ```
 
 If this method is not present on your notification, the notification will *not* be interrupted. Consider creating a shouldInterupt trait if you'd like to repeat conditional logic on groups of notifications.
+
+**Scheduled Notification Meta Information**
+
+It's possible to store meta information on a scheduled notification, and then query the scheduled notifications by this meta information at a later stage.
+
+This functionality could be useful for when you store notifications for a future date, but some change in the system requires
+you to update them. By using the meta column, it's possible to more easily query these scheduled notifications from the database by something else than
+the notifiable.
+
+***Storing Meta Information***
+
+Using the `ScheduledNotification::create` helper
+
+```php
+ScheduledNotification::create(
+     $target, // Target
+     new ScheduledNotificationExample($order), // Notification
+     Carbon::now()->addDay(), // Send At,
+     ['foo' => 'bar'] // Meta Information
+);
+```
+
+Using the `notifyAt` trait
+
+```php
+  $user->notifyAt(new BirthdayNotification, Carbon::parse($user->birthday), ['foo' => 'bar']);
+```
+
+***Retrieving Meta Information from Scheduled Notifications***
+
+You can call the `getMeta` function on an existing scheduled notification to retrieve the meta information for the specific notification.
+
+Passing no parameters to this function will return the entire meta column in array form.
+
+Passing a string key (`getMeta('foo')`), will retrieve the specific key from the meta column.
+
+***Querying Scheduled Notifications using the ScheduledNotification::findByMeta helper***
+
+It's possible to query the database for scheduled notifications with certain meta information, by using the `findByMeta` helper.
+
+```php
+  ScheduledNotification::findByMeta('foo', 'bar'); //key and value
+```
+
+The first parameter is the meta key, and the second parameter is the value to look for.
+
+>Note: The index column doesn't currently make use of a database index
 
 **Conditionally turn off scheduler**
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,9 @@ composer test
 
 If you discover any security related issues, please email instead of using the issue tracker.
 
+## Changelog
+Please be sure to run `php artisan migrate` when upgrading versions of this package.
+
 ## Contributing
 
 1. Fork it (<https://github.com/thomasjohnkane/snooze/fork>)

--- a/migrations/2021_09_10_130000_add_meta_to_scheduled_notifications.php
+++ b/migrations/2021_09_10_130000_add_meta_to_scheduled_notifications.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMetaToScheduledNotifications extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(config('snooze.table'), function (Blueprint $table) {
+            $table->json('meta')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(config('snooze.table'), function (Blueprint $table) {
+            $table->dropColumn('meta');
+        });
+    }
+}

--- a/src/Models/ScheduledNotification.php
+++ b/src/Models/ScheduledNotification.php
@@ -36,12 +36,17 @@ class ScheduledNotification extends Model
         'cancelled',
         'created_at',
         'updated_at',
+        'meta',
     ];
 
     protected $attributes = [
         'sent_at' => null,
         'rescheduled_at' => null,
         'cancelled_at' => null,
+    ];
+
+    protected $casts = [
+        'meta' => 'array'
     ];
 
     public function __construct(array $attributes = [])

--- a/src/Models/ScheduledNotification.php
+++ b/src/Models/ScheduledNotification.php
@@ -46,7 +46,7 @@ class ScheduledNotification extends Model
     ];
 
     protected $casts = [
-        'meta' => 'array'
+        'meta' => 'array',
     ];
 
     public function __construct(array $attributes = [])

--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -27,10 +27,10 @@ class ScheduledNotification
     }
 
     /**
-     * @param object $notifiable
-     * @param Notification $notification
-     * @param DateTimeInterface $sendAt
-     * @param array $meta
+     * @param  object  $notifiable
+     * @param  Notification  $notification
+     * @param  DateTimeInterface  $sendAt
+     * @param  array  $meta
      * @return self
      *
      * @throws SchedulingFailedException
@@ -172,8 +172,8 @@ class ScheduledNotification
     }
 
     /**
-     * @param DateTimeInterface|string $sendAt
-     * @param bool $force
+     * @param  DateTimeInterface|string  $sendAt
+     * @param  bool  $force
      * @return self
      *
      * @throws NotificationAlreadySentException

--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -185,7 +185,7 @@ class ScheduledNotification
     }
 
     /**
-     * @param DateTimeInterface|string $sendAt
+     * @param  DateTimeInterface|string  $sendAt
      * @return self
      */
     public function scheduleAgainAt($sendAt): self
@@ -293,7 +293,7 @@ class ScheduledNotification
     }
 
     /**
-     * @param null $key
+     * @param  null  $key
      */
     public function getMeta($key = null)
     {

--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -102,7 +102,8 @@ class ScheduledNotification
         return self::collection($models);
     }
 
-    public static function findByMeta($key, $value){
+    public static function findByMeta($key, $value): ?Collection
+    {
 
         $modelClass = self::getScheduledNotificationModelClass();
 

--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -32,6 +32,7 @@ class ScheduledNotification
      * @param DateTimeInterface $sendAt
      * @param array $meta
      * @return self
+     *
      * @throws SchedulingFailedException
      */
     public static function create(
@@ -88,7 +89,7 @@ class ScheduledNotification
 
     public static function findByTarget(object $notifiable): ?Collection
     {
-        if (!$notifiable instanceof Model) {
+        if (! $notifiable instanceof Model) {
             return null;
         }
 
@@ -173,8 +174,8 @@ class ScheduledNotification
     /**
      * @param DateTimeInterface|string $sendAt
      * @param bool $force
-     *
      * @return self
+     *
      * @throws NotificationAlreadySentException
      * @throws NotificationCancelledException
      */
@@ -185,7 +186,6 @@ class ScheduledNotification
 
     /**
      * @param DateTimeInterface|string $sendAt
-     *
      * @return self
      */
     public function scheduleAgainAt($sendAt): self

--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -30,7 +30,7 @@ class ScheduledNotification
      * @param object $notifiable
      * @param Notification $notification
      * @param DateTimeInterface $sendAt
-     *
+     * @param array $meta
      * @return self
      * @throws SchedulingFailedException
      */
@@ -45,7 +45,7 @@ class ScheduledNotification
                 $sendAt->format(DATE_ISO8601)));
         }
 
-        if (!method_exists($notifiable, 'notify')) {
+        if (! method_exists($notifiable, 'notify')) {
             throw new SchedulingFailedException(sprintf('%s is not notifiable', get_class($notifiable)));
         }
 
@@ -62,7 +62,7 @@ class ScheduledNotification
             'target'            => $serializer->serialize($notifiable),
             'notification'      => $serializer->serialize($notification),
             'send_at'           => $sendAt,
-            'meta'              => $meta
+            'meta'              => $meta,
         ]));
     }
 
@@ -118,11 +118,11 @@ class ScheduledNotification
         $modelClass = self::getScheduledNotificationModelClass();
         $query = $modelClass::query();
 
-        if (!$includeSent) {
+        if (! $includeSent) {
             $query->whereNull('sent_at');
         }
 
-        if (!$includeCanceled) {
+        if (! $includeCanceled) {
             $query->whereNull('cancelled_at');
         }
 
@@ -131,7 +131,7 @@ class ScheduledNotification
 
     public static function cancelByTarget(object $notifiable): int
     {
-        if (!$notifiable instanceof Model) {
+        if (! $notifiable instanceof Model) {
             throw new LaravelSnoozeException(
                 'Cannot cancel AnonymousNotifiable by instance. Use the `cancelAnonymousNotificationsByChannel` method instead');
         }

--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -39,7 +39,7 @@ class ScheduledNotification
         object $notifiable,
         Notification $notification,
         DateTimeInterface $sendAt,
-        $meta = []
+        array $meta = []
     ): self {
         if ($sendAt <= Carbon::now()->subMinute()) {
             throw new SchedulingFailedException(sprintf('`send_at` must not be in the past: %s',

--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -102,6 +102,17 @@ class ScheduledNotification
         return self::collection($models);
     }
 
+    public static function findByMeta($key, $value){
+
+        $modelClass = self::getScheduledNotificationModelClass();
+
+        $models = $modelClass::query()
+            ->where("meta->{$key}", $value)
+            ->get();
+
+        return self::collection($models);
+    }
+
     public static function all(bool $includeSent = false, bool $includeCanceled = false): Collection
     {
         $modelClass = self::getScheduledNotificationModelClass();

--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -104,7 +104,6 @@ class ScheduledNotification
 
     public static function findByMeta($key, $value): ?Collection
     {
-
         $modelClass = self::getScheduledNotificationModelClass();
 
         $models = $modelClass::query()
@@ -301,7 +300,7 @@ class ScheduledNotification
         if (is_null($key)) {
             return $this->scheduleNotificationModel->meta;
         } else {
-            return $this->scheduleNotificationModel->meta[$key];
+            return $this->scheduleNotificationModel->meta[$key] ?? [];
         }
     }
 

--- a/src/Traits/SnoozeNotifiable.php
+++ b/src/Traits/SnoozeNotifiable.php
@@ -12,14 +12,15 @@ use Thomasjohnkane\Snooze\ScheduledNotification;
 trait SnoozeNotifiable
 {
     /**
-     * @param Notification      $notification
+     * @param Notification $notification
      * @param DateTimeInterface $sendAt
+     * @param array $meta
      *
      * @return ScheduledNotification
      * @throws SchedulingFailedException
      */
-    public function notifyAt($notification, DateTimeInterface $sendAt): ScheduledNotification
+    public function notifyAt($notification, DateTimeInterface $sendAt, array $meta = []): ScheduledNotification
     {
-        return ScheduledNotification::create($this, $notification, $sendAt);
+        return ScheduledNotification::create($this, $notification, $sendAt, $meta);
     }
 }

--- a/src/Traits/SnoozeNotifiable.php
+++ b/src/Traits/SnoozeNotifiable.php
@@ -15,8 +15,8 @@ trait SnoozeNotifiable
      * @param Notification $notification
      * @param DateTimeInterface $sendAt
      * @param array $meta
-     *
      * @return ScheduledNotification
+     *
      * @throws SchedulingFailedException
      */
     public function notifyAt($notification, DateTimeInterface $sendAt, array $meta = []): ScheduledNotification

--- a/src/Traits/SnoozeNotifiable.php
+++ b/src/Traits/SnoozeNotifiable.php
@@ -12,9 +12,9 @@ use Thomasjohnkane\Snooze\ScheduledNotification;
 trait SnoozeNotifiable
 {
     /**
-     * @param Notification $notification
-     * @param DateTimeInterface $sendAt
-     * @param array $meta
+     * @param  Notification  $notification
+     * @param  DateTimeInterface  $sendAt
+     * @param  array  $meta
      * @return ScheduledNotification
      *
      * @throws SchedulingFailedException

--- a/tests/ScheduledNotificationTest.php
+++ b/tests/ScheduledNotificationTest.php
@@ -35,7 +35,7 @@ class ScheduledNotificationTest extends TestCase
             'cancelled_at',
             'created_at',
             'updated_at',
-            'meta'
+            'meta',
         ], $columns);
     }
 

--- a/tests/ScheduledNotificationTest.php
+++ b/tests/ScheduledNotificationTest.php
@@ -34,6 +34,7 @@ class ScheduledNotificationTest extends TestCase
             'cancelled_at',
             'created_at',
             'updated_at',
+            'meta'
         ], $columns);
     }
 
@@ -302,5 +303,20 @@ class ScheduledNotificationTest extends TestCase
 
         $this->assertInstanceOf(TestNotification::class, $scheduled_notification->getNotification());
         $this->assertEquals($scheduled_notification->getNotification()->newUser->email, $notification->newUser->email);
+    }
+
+    public function testItCanStoreAndRetrieveMetaInfo()
+    {
+        $target = User::find(1);
+        $notification = new TestNotification(User::find(2));
+
+        $meta = ['foo' => 'bar', 'hey' => 'you'];
+
+        $scheduled_notification = ScheduledNotification::create($target, $notification, Carbon::now()->addSeconds(10), $meta);
+
+        $this->assertSame($meta, $scheduled_notification->getMeta());
+
+        $this->assertSame("bar", $scheduled_notification->getMeta('foo'));
+        $this->assertSame("you", $scheduled_notification->getMeta('hey'));
     }
 }

--- a/tests/ScheduledNotificationTest.php
+++ b/tests/ScheduledNotificationTest.php
@@ -247,7 +247,8 @@ class ScheduledNotificationTest extends TestCase
         ScheduledNotification::create(
             $target,
             new TestNotification(User::find(2)),
-            Carbon::now()->addSeconds(10)
+            Carbon::now()->addSeconds(10),
+            ['foo' => 'baz']
         );
 
         ScheduledNotification::create(
@@ -259,7 +260,8 @@ class ScheduledNotificationTest extends TestCase
         ScheduledNotification::create(
             $target,
             new TestNotification(User::find(2)),
-            Carbon::now()->addSeconds(60)
+            Carbon::now()->addSeconds(60),
+            ['foo' => 'bar']
         );
 
         ScheduledNotification::create(
@@ -271,7 +273,8 @@ class ScheduledNotificationTest extends TestCase
         ScheduledNotification::create(
             $target,
             new TestNotificationTwo(User::find(2)),
-            Carbon::now()->addSeconds(60)
+            Carbon::now()->addSeconds(60),
+            ['foo' => 'bar']
         );
 
         $all = ScheduledNotification::all();
@@ -284,6 +287,9 @@ class ScheduledNotificationTest extends TestCase
         $this->assertSame(2, $type2->count());
 
         $this->assertSame(5, ScheduledNotification::findByTarget($target)->count());
+
+        $this->assertSame(2, ScheduledNotification::findByMeta('foo', 'bar')->count());
+        $this->assertSame(1, ScheduledNotification::findByMeta('foo', 'baz')->count());
 
         $all->first()->sendNow();
 
@@ -319,4 +325,5 @@ class ScheduledNotificationTest extends TestCase
         $this->assertSame("bar", $scheduled_notification->getMeta('foo'));
         $this->assertSame("you", $scheduled_notification->getMeta('hey'));
     }
+
 }

--- a/tests/ScheduledNotificationTest.php
+++ b/tests/ScheduledNotificationTest.php
@@ -320,11 +320,14 @@ class ScheduledNotificationTest extends TestCase
         $meta = ['foo' => 'bar', 'hey' => 'you'];
 
         $scheduled_notification = ScheduledNotification::create($target, $notification, Carbon::now()->addSeconds(10), $meta);
+        $scheduled_notification_no_meta = ScheduledNotification::create($target, $notification, Carbon::now()->addSeconds(10));
 
         $this->assertSame($meta, $scheduled_notification->getMeta());
+        $this->assertSame([], $scheduled_notification_no_meta->getMeta());
 
         $this->assertSame("bar", $scheduled_notification->getMeta('foo'));
         $this->assertSame("you", $scheduled_notification->getMeta('hey'));
+        $this->assertSame([], $scheduled_notification->getMeta('doesnt_exist'));
     }
 
 }

--- a/tests/ScheduledNotificationTest.php
+++ b/tests/ScheduledNotificationTest.php
@@ -325,8 +325,8 @@ class ScheduledNotificationTest extends TestCase
         $this->assertSame($meta, $scheduled_notification->getMeta());
         $this->assertSame([], $scheduled_notification_no_meta->getMeta());
 
-        $this->assertSame("bar", $scheduled_notification->getMeta('foo'));
-        $this->assertSame("you", $scheduled_notification->getMeta('hey'));
+        $this->assertSame('bar', $scheduled_notification->getMeta('foo'));
+        $this->assertSame('you', $scheduled_notification->getMeta('hey'));
         $this->assertSame([], $scheduled_notification->getMeta('doesnt_exist'));
     }
 

--- a/tests/ScheduledNotificationTest.php
+++ b/tests/ScheduledNotificationTest.php
@@ -329,5 +329,4 @@ class ScheduledNotificationTest extends TestCase
         $this->assertSame('you', $scheduled_notification->getMeta('hey'));
         $this->assertSame([], $scheduled_notification->getMeta('doesnt_exist'));
     }
-
 }


### PR DESCRIPTION
Hi @atymic and @thomasjohnkane 

This pr adds in the ability to save meta info for a scheduled notification, and then be able to query for scheduled notifications by some meta fields as needed by the developer.

The `notifyAt` and `create` method's signature changes to include one new optional parameter, which is the meta array.

```php
    public function notifyAt($notification, DateTimeInterface $sendAt, array $meta = []): ScheduledNotification
    {
        return ScheduledNotification::create($this, $notification, $sendAt, $meta);
    }
```

A new `findByMeta` function is defined to be able to find scheduled notifications based on some meta info:

```php 
ScheduledNotification::findByMeta('foo', 'bar')
```

It is also possible to call `getMeta` on the notification itself to get all meta information or a specific key:
(from the tests)

```php
   $this->assertSame($meta, $scheduled_notification->getMeta());

        $this->assertSame("bar", $scheduled_notification->getMeta('foo'));
        $this->assertSame("you", $scheduled_notification->getMeta('hey'));
```

**Tests**
I've added a new testItCanStoreAndRetrieveMetaInfo test and updated `testNotificationsCanBeQueried` to include querying by meta

**Migrations**
This pr adds one migration which is the new nullable meta field

**Use case**
For my use case, we use this package to schedule notifications of upcoming calendar events, which could be anywhere in the future. As the user is the notifiable entity, it's not easy to be able to find all upcoming notifications for a specific event.

With this pr, it will be able to add meta info like event_id = 1 to an upcoming notification, and then query for all scheduled notifications in the database for this event with `ScheduledNotification::findByMeta('event_id', 1)`

I can see many reasons to need to do something like this for future notifications, for instance I need it to be able to easily update already scheduled events if a certain start time of an event has changed, this pr will make this and similar scenarios much easier.




