### PR TITLE
Feat: Config option to disable automatically adding `snooze:send` and `snooze:prune` to the schedular

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ The `snooze:send` command is scheduled to run every minute by default. You can c
 
 The only thing you need to do is make sure `schedule:run` is also running. You can test this by running `php artisan schedule:run` in the console. [To make it run automatically, read here][6].
 
+>Note: If you would prefer snooze to not automatically schedule the commands, you can set the `scheduleCommands` config value to `false`
+
 ### Setting the send tolerance
 
 If your scheduler stops working, a backlog of scheduled notifications will build up. To prevent users receiving all of

--- a/config/snooze.php
+++ b/config/snooze.php
@@ -46,4 +46,9 @@ return [
      * Should the snooze commands utilise the Laravel onOneServer functionality
      */
     'onOneServer' => env('SCHEDULED_NOTIFICATIONS_ONE_SERVER', false),
+
+    /*
+     * Should snooze automatically schedule the snooze:send and snooze:prune commands
+     */
+    'scheduleCommands' => env('SCHEDULED_NOTIFICATIONS_SCHEDULE_COMMANDS', true),
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,7 +17,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
 
         //Check if snooze should schedule the commands automatically
-        if(config('snooze.scheduleCommands', true)){
+        if (config('snooze.scheduleCommands', true)) {
 
             // Schedule base command to run every minute
             $this->app->booted(function () {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -15,29 +15,37 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
     public function boot()
     {
-        // Schedule base command to run every minute
-        $this->app->booted(function () {
 
-            //Ensure the schedule is available if snooze is disabled but a prune age is set
-            $schedule = $this->app->make(Schedule::class);
+        //Check if snooze should schedule the commands automatically
+        if(config('snooze.scheduleCommands', true)){
 
-            if (! config('snooze.disabled')) {
-                $frequency = config('snooze.sendFrequency', 'everyMinute');
-                if (config('snooze.onOneServer', false)) {
-                    $schedule->command('snooze:send')->{$frequency}()->onOneServer();
-                } else {
-                    $schedule->command('snooze:send')->{$frequency}();
+            // Schedule base command to run every minute
+            $this->app->booted(function () {
+
+
+                //Ensure the schedule is available if snooze is disabled but a prune age is set
+                $schedule = $this->app->make(Schedule::class);
+
+                if (! config('snooze.disabled')) {
+                    $frequency = config('snooze.sendFrequency', 'everyMinute');
+                    if (config('snooze.onOneServer', false)) {
+                        $schedule->command('snooze:send')->{$frequency}()->onOneServer();
+                    } else {
+                        $schedule->command('snooze:send')->{$frequency}();
+                    }
                 }
-            }
 
-            if (config('snooze.pruneAge') !== null) {
-                if (config('snooze.onOneServer', false)) {
-                    $schedule->command('snooze:prune')->daily()->onOneServer();
-                } else {
-                    $schedule->command('snooze:prune')->daily();
+                if (config('snooze.pruneAge') !== null) {
+                    if (config('snooze.onOneServer', false)) {
+                        $schedule->command('snooze:prune')->daily()->onOneServer();
+                    } else {
+                        $schedule->command('snooze:prune')->daily();
+                    }
                 }
-            }
-        });
+            });
+        }
+
+
 
         $this->publishes([
             self::CONFIG_PATH => config_path('snooze.php'),

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -22,7 +22,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             // Schedule base command to run every minute
             $this->app->booted(function () {
 
-
                 //Ensure the schedule is available if snooze is disabled but a prune age is set
                 $schedule = $this->app->make(Schedule::class);
 
@@ -44,8 +43,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 }
             });
         }
-
-
 
         $this->publishes([
             self::CONFIG_PATH => config_path('snooze.php'),


### PR DESCRIPTION
Hi @atymic and @thomasjohnkane 

Snooze currently automatically adds the `snooze:send` and `snooze:prune` commands to the scheduler. 

This is convenient for 95% of the use cases, but becomes a bit of a problem if the project requires turning that off by default.

For example in our project we are making use of the spatie multi tenant package. If we want to run commands for all our tenants, we need to prefix the command with `tenants:artisan` (This way the active database will be set for each tenant)

So to schedule the send command as an example, we require doing the below:

```php         
$schedule->command('tenants:artisan snooze:send')->everyMinute()->onOneServer()->runInBackground();
```

Not being able to turn off automatically scheduling these commands, results in there always being a `snooze:prune`  or `snooze:send`command scheduled, and these will fail every time they run as the current database won't be set.

To get around this currently I need to do some ugly config juggling, and actually disable snooze so it doesn't schedule the command, and the only way to not schedule the prune command is to have pruneAge set to null.

Since this might be the situation for other users, I thought of introducing a new config option `scheduleCommands`, which defaults to `true` to keep current behavior, but can be set to `false` if you don't want nooze to automatically schedule the commands.

```php
/*
* Should snooze automatically schedule the snooze:send and snooze:prune commands
*/
'scheduleCommands' => env('SCHEDULED_NOTIFICATIONS_SCHEDULE_COMMANDS', true),
``` 

Note that the commands are always registered, this config option just determines if it should be added to the scheduler automatically or not.

There is no breaking change here as it defaults to true for the config option.

I've also added a note to the readme to indicate this option.