### PR TITLE
use custom model in send command

### DIFF
--- a/src/Console/Commands/SendScheduledNotifications.php
+++ b/src/Console/Commands/SendScheduledNotifications.php
@@ -2,9 +2,9 @@
 
 namespace Thomasjohnkane\Snooze\Console\Commands;
 
-use Carbon\Carbon;
 use Illuminate\Console\Command;
-use Thomasjohnkane\Snooze\Models\ScheduledNotification;
+use Thomasjohnkane\Snooze\Models\ScheduledNotification as ScheduledNotificationModel;
+use Thomasjohnkane\Snooze\ScheduledNotification;
 
 class SendScheduledNotifications extends Command
 {
@@ -31,11 +31,7 @@ class SendScheduledNotifications extends Command
     {
         $tolerance = config('snooze.sendTolerance');
 
-        $notifications = ScheduledNotification::whereNull('sent_at')
-                                ->whereNull('cancelled_at')
-                                ->where('send_at', '<=', Carbon::now())
-                                ->where('send_at', '>=', Carbon::now()->subSeconds($tolerance ?? 60))
-                                ->get();
+        $notifications = ScheduledNotification::getPendingNotifications($tolerance);
 
         if (! $notifications->count()) {
             $this->info('No Scheduled Notifications need to be sent.');
@@ -51,7 +47,7 @@ class SendScheduledNotifications extends Command
 
         $this->info(sprintf('Sending %d scheduled notifications...', $notifications->count()));
 
-        $notifications->each(function (ScheduledNotification $notification) use ($bar) {
+        $notifications->each(function (ScheduledNotificationModel $notification) use ($bar) {
             $bar->advance();
 
             try {

--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -66,6 +66,18 @@ class ScheduledNotification
         ]));
     }
 
+    public static function getPendingNotifications(int $tolerance = null): \Illuminate\Database\Eloquent\Collection
+    {
+        $modelClass = self::getScheduledNotificationModelClass();
+
+        return $modelClass::query()
+            ->whereNull('sent_at')
+            ->whereNull('cancelled_at')
+            ->where('send_at', '<=', Carbon::now())
+            ->where('send_at', '>=', Carbon::now()->subSeconds($tolerance ?? 60))
+            ->get();
+    }
+
     public static function find(int $scheduledNotificationId): ?self
     {
         $modelClass = self::getScheduledNotificationModelClass();

--- a/tests/Models/CustomScheduledNotification.php
+++ b/tests/Models/CustomScheduledNotification.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Thomasjohnkane\Snooze\Tests\Models;
+
+use Exception;
+use Thomasjohnkane\Snooze\Models\ScheduledNotification;
+
+class CustomScheduledNotification extends ScheduledNotification
+{
+    public function send(): void
+    {
+        throw new Exception('Custom send method');
+    }
+}


### PR DESCRIPTION
In the send command, the default model was used even if the model was changed in the configuration file. This change allows the user to extend and overwrite the send function such that the package is more flexible.

Closes #129 