### PR TITLE
add should reschedule for

### DIFF
--- a/src/Events/NotificationRescheduled.php
+++ b/src/Events/NotificationRescheduled.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Thomasjohnkane\Snooze\Events;
+
+use Illuminate\Queue\SerializesModels;
+use Thomasjohnkane\Snooze\Models\ScheduledNotification;
+
+class NotificationRescheduled
+{
+    use SerializesModels;
+
+    public $scheduledNotification;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Thomasjohnkane\Snooze\Models\ScheduledNotification  $scheduledNotification
+     * @return void
+     */
+    public function __construct(ScheduledNotification $scheduledNotification)
+    {
+        $this->scheduledNotification = $scheduledNotification;
+    }
+}

--- a/src/Models/ScheduledNotification.php
+++ b/src/Models/ScheduledNotification.php
@@ -78,7 +78,7 @@ class ScheduledNotification extends Model
             return;
         }
 
-        if($sendAt = $this->shouldRescheduleFor($notification, $notifiable)) {
+        if ($sendAt = $this->shouldRescheduleFor($notification, $notifiable)) {
             $this->reschedule($sendAt);
             event(new NotificationRescheduled($this));
 
@@ -116,11 +116,12 @@ class ScheduledNotification extends Model
     }
 
     /**
-     * @param object|null $notification
-     * @param object|null $notifiable
+     * @param  object|null  $notification
+     * @param  object|null  $notifiable
      * @return \DateTimeInterface|string|null
      */
-    public function shouldRescheduleFor(?object $notification = null, ?object $notifiable = null) {
+    public function shouldRescheduleFor(?object $notification = null, ?object $notifiable = null)
+    {
         if (! $notification) {
             $notification = $this->serializer->unserialize($this->notification);
         }

--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -312,6 +312,14 @@ class ScheduledNotification
         return $this->scheduleNotificationModel->shouldInterrupt();
     }
 
+    /**
+     * @return \DateTimeInterface|string|null
+     */
+    public function shouldRescheduleFor()
+    {
+        return $this->scheduleNotificationModel->shouldRescheduleFor();
+    }
+
     private static function getScheduledNotificationModelClass(): string
     {
         return config('snooze.model') ?? ScheduledNotificationModel::class;

--- a/tests/CanRescheduleNotificationTest.php
+++ b/tests/CanRescheduleNotificationTest.php
@@ -5,11 +5,9 @@ namespace Thomasjohnkane\Snooze\Tests;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
-use Thomasjohnkane\Snooze\Events\NotificationInterrupted;
 use Thomasjohnkane\Snooze\Events\NotificationRescheduled;
 use Thomasjohnkane\Snooze\Models\ScheduledNotification;
 use Thomasjohnkane\Snooze\Tests\Models\User;
-use Thomasjohnkane\Snooze\Tests\Notifications\TestInterruptableNotification;
 use Thomasjohnkane\Snooze\Tests\Notifications\TestReschedulableNotification;
 
 class CanRescheduleNotificationTest extends TestCase

--- a/tests/CanRescheduleNotificationTest.php
+++ b/tests/CanRescheduleNotificationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Thomasjohnkane\Snooze\Tests;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use Thomasjohnkane\Snooze\Events\NotificationInterrupted;
+use Thomasjohnkane\Snooze\Events\NotificationRescheduled;
+use Thomasjohnkane\Snooze\Models\ScheduledNotification;
+use Thomasjohnkane\Snooze\Tests\Models\User;
+use Thomasjohnkane\Snooze\Tests\Notifications\TestInterruptableNotification;
+use Thomasjohnkane\Snooze\Tests\Notifications\TestReschedulableNotification;
+
+class CanRescheduleNotificationTest extends TestCase
+{
+    public function testNotificationIsRescheduled()
+    {
+        Notification::fake();
+        Event::fake();
+
+        // User id 1 should be interrupted
+        $target = User::find(1);
+        $notification = $target->notifyAt(new TestReschedulableNotification(User::find(2)), Carbon::now()->subSeconds(10));
+        $this->assertDatabaseHas('scheduled_notifications', ['id' => $notification->getId()]);
+
+        $this->artisan('snooze:send');
+
+        $notification->refresh();
+        $this->assertFalse($notification->isSent());
+        $this->assertFalse($notification->isCancelled());
+        $this->assertNotNull($notification->shouldRescheduleFor());
+
+        Notification::assertNothingSent();
+        Event::assertDispatched(NotificationRescheduled::class, 1);
+    }
+
+    public function testNotificationIsNotRescheduled()
+    {
+        Notification::fake();
+        Event::fake();
+
+        // User id 2 should NOT be rescheduled.
+        $target = User::find(2);
+
+        $notification = $target->notifyAt(new TestReschedulableNotification(User::find(2)), Carbon::now()->subSeconds(10));
+        $this->assertDatabaseHas('scheduled_notifications', ['id' => $notification->getId()]);
+        $this->artisan('snooze:send');
+
+        $notification->refresh();
+        $this->assertTrue($notification->isSent());
+        $this->assertFalse($notification->isCancelled());
+        $this->assertNull($notification->shouldRescheduleFor());
+    }
+
+    public function testInterruptMethodReceivesNotifiable()
+    {
+        $target = User::find(3);
+
+        $notificationMock = $this->createMock(TestReschedulableNotification::class);
+        $notificationMock
+            ->expects($this->once())
+            ->method('shouldRescheduleFor')
+            ->with($target)
+            ->willReturn(null);
+
+        $model = new ScheduledNotification();
+        $model->shouldRescheduleFor($notificationMock, $target);
+    }
+}

--- a/tests/Notifications/TestReschedulableNotification.php
+++ b/tests/Notifications/TestReschedulableNotification.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Thomasjohnkane\Snooze\Tests\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Thomasjohnkane\Snooze\Tests\Models\User;
+
+class TestReschedulableNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /** @var User */
+    public $newUser;
+
+    /**
+     * @param  User  $newUser
+     */
+    public function __construct(User $newUser)
+    {
+        $this->newUser = $newUser;
+    }
+
+    /**
+     * Get the notification's channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array|string
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('New User')
+            ->line(sprintf('Email: %s', $this->newUser->email));
+    }
+
+    public function shouldRescheduleFor(object $notifiable)
+    {
+        if($notifiable->id === 1){
+            return now()->addMinutes(5);
+        }
+
+        return null;
+    }
+}

--- a/tests/Notifications/TestReschedulableNotification.php
+++ b/tests/Notifications/TestReschedulableNotification.php
@@ -43,7 +43,7 @@ class TestReschedulableNotification extends Notification implements ShouldQueue
 
     public function shouldRescheduleFor(object $notifiable)
     {
-        if($notifiable->id === 1){
+        if ($notifiable->id === 1) {
             return now()->addMinutes(5);
         }
 


### PR DESCRIPTION
It adds a `shouldRescheduleFor` check, similar to `shouldInterrupt`. This would allow using the scheduled notifications for use-cases where we are waiting for a job to be done (my use case was waiting for archiving a lot of photos in and then sending a email notification with a download link)