### PR TITLE
Add model date casts for Laravel 10

### DIFF
--- a/src/Models/ScheduledNotification.php
+++ b/src/Models/ScheduledNotification.php
@@ -47,6 +47,10 @@ class ScheduledNotification extends Model
 
     protected $casts = [
         'meta' => 'array',
+        'send_at' => 'datetime',
+        'sent_at' => 'datetime',
+        'rescheduled_at' => 'datetime',
+        'cancelled_at' => 'datetime',
     ];
 
     public function __construct(array $attributes = [])


### PR DESCRIPTION
Laravel 8 deprecated use of the `$dates` property on Eloquent models and Laravel 10 removed use of it entirely in favor of `$casts`. Add these casts to work with Laravel 10 and leave the existing `$dates` property in place to allow compatibility with older Laravel versions.

Closes #111