### PR TITLE
Add rescheduled_at, cancelled_at properties to fillable array

### DIFF
--- a/src/Models/ScheduledNotification.php
+++ b/src/Models/ScheduledNotification.php
@@ -34,6 +34,8 @@ class ScheduledNotification extends Model
         'sent_at',
         'rescheduled',
         'cancelled',
+        'rescheduled_at',
+        'cancelled_at',
         'created_at',
         'updated_at',
         'meta',


### PR DESCRIPTION
I had issues with mass assignment when Laravel strict mode is enabled. This PR is created to add needed properties to fillable array on Thomasjohnkane\Snooze\Models\ScheduledNotification.