### PR TITLE
Add config option to disable migration auto registration

### DIFF
--- a/config/snooze.php
+++ b/config/snooze.php
@@ -51,4 +51,9 @@ return [
      * Should snooze automatically schedule the snooze:send and snooze:prune commands
      */
     'scheduleCommands' => env('SCHEDULED_NOTIFICATIONS_SCHEDULE_COMMANDS', true),
+
+    /*
+     * Should snooze automatically register the migrations
+     */
+    'registerMigrations' => env('SCHEDULED_NOTIFICATIONS_REGISTER_MIGRATIONS', true),
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -48,7 +48,9 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             self::CONFIG_PATH => config_path('snooze.php'),
         ], 'config');
 
-        $this->loadMigrationsFrom(__DIR__.'/../migrations');
+        if (config('snooze.registerMigrations', true)) {
+            $this->loadMigrationsFrom(__DIR__.'/../migrations');
+        }
 
         if ($this->app->runningInConsole()) {
             $this->commands($this->commands);


### PR DESCRIPTION
Auto-registration of the migrations is a nice feature, but might be unwanted in some cases. For example when used with a tenancy solution like `stancyl/tenancy`. This PR adds a new config option to manage the auto registration of the migrations. It defaults to true so it's backwards compatible.